### PR TITLE
Test using multiple JDK versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,14 @@
 language: java
 
+jdk:
+  - oraclejdk8
+  - openjdk7
+  - openjdk6
+
+# @see https://github.com/travis-ci/travis-ci/issues/3259#issuecomment-130860338
+sudo: false
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+


### PR DESCRIPTION
Since some JDKs threat conditions differently than others, we'll make use of TravisCI's capability to [test against multiple JDK versions](https://docs.travis-ci.com/user/languages/java/#Testing-Against-Multiple-JDKs) at once.